### PR TITLE
Upstream versioning scheme has changed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN set -eux; \
         perl-net-dns \
         curl \
         tzdata; \
-    curl -SLk http://www.jetmore.org/john/code/swaks/files/swaks-$SWAKS_VERSION/swaks -o swaks; \
+    curl -SLk https://www.jetmore.org/john/code/swaks/files/swaks-$SWAKS_VERSION/swaks -o swaks; \
     chmod +x swaks; \
     mv swaks /usr/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.12
 
 MAINTAINER Peter Szalatnay <theotherland@gmail.com>
 
-ENV SWAKS_VERSION=20190914-0
+ENV SWAKS_VERSION=20190914.0
 
 RUN set -eux; \
     apk add --update --no-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.12
 
 MAINTAINER Peter Szalatnay <theotherland@gmail.com>
 
-ENV SWAKS_VERSION=20190914.0
+ENV SWAKS_VERSION=20201014.0
 
 RUN set -eux; \
     apk add --update --no-cache \

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ### SWAKS version
 
- This image uses SWAKS [20190914-0](https://www.jetmore.org/john/blog/2019/10/swaks-release-20190914-0-available/) ([full changelog](http://jetmore.org/john/code/swaks/files/swaks-20190914-0/doc/Changes.txt))
+ This image uses SWAKS [20201014.0](https://www.jetmore.org/john/blog/2020/10/swaks-release-20201014-0-available/) ([full changelog](https://jetmore.org/john/code/swaks/files/swaks-20201014.0/doc/Changes.txt))
 
 
 ## Info
@@ -20,7 +20,7 @@ This image is based on the popular Alpine Linux project, available in the alpine
 
 ## Usage
 
-Refer to this doc for [command line options](http://jetmore.org/john/code/swaks/files/swaks-20181104.0/doc/ref.txt)
+Refer to this doc for [command line options](https://jetmore.org/john/code/swaks/files/swaks-20201014.0/doc/ref.txt)
 
 ### Simple
 


### PR DESCRIPTION
The upstream versioning scheme appears to have changed. As a result the current URL for `swaks` script yields a 404.  (Which results in a broken docker image since the entrypoint, `/usr/bin/swaks`, contains an HTML *not found* message.)

This fixes that.

This PR also includes:
- switch to using SSL to fetch the script
- update to latest version of *swaks* (20201014.0)
