### PR TITLE
add NTLM auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,13 @@ RUN set -eux; \
         perl-net-ssleay \
         perl-net-dns \
         curl \
+        make \
         tzdata; \
     curl -SLk https://www.jetmore.org/john/code/swaks/files/swaks-$SWAKS_VERSION/swaks -o swaks; \
     chmod +x swaks; \
+    yes | perl -MCPAN -e 'install Authen::NTLM' \
+    rm -rf /root/.cpan \
+    apk remove make \
     mv swaks /usr/bin
 
 WORKDIR /root


### PR DESCRIPTION
This commit adds NTLM capability to swaks so it can work with MS Exchange Servers where only AUTH NTLM is present.